### PR TITLE
Add manual cache update route to development mode

### DIFF
--- a/apps/ralts/src/index.ts
+++ b/apps/ralts/src/index.ts
@@ -16,10 +16,22 @@ app.get('/', async (req, res) => {
 
   res.json({
     type: 'cache',
-    test: 'hello from ralts',
     cache,
   });
 });
+console.log(process.env.NODE_ENV);
+
+if (process.env.NODE_ENV === 'development') {
+  app.get('/nocache', async (req, res) => {
+    await updateCache();
+    const cache = await getCache();
+
+    return res.json({
+      type: 'cache',
+      cache
+    })
+  })
+}
 
 app.listen(3005, async () => {
   try {

--- a/apps/ralts/src/index.ts
+++ b/apps/ralts/src/index.ts
@@ -7,7 +7,8 @@ import { isCacheStale } from './cache/is-cache-stale';
 const {
   VITE_RALTS_PORT,
   SMEARGLE_PORT,
-  SMEARGLE_DOMAIN
+  SMEARGLE_DOMAIN,
+  NODE_ENV
 } = process.env
 
 const app = express();
@@ -25,9 +26,8 @@ app.get('/', async (req, res) => {
     cache,
   });
 });
-console.log(process.env.NODE_ENV);
 
-if (process.env.NODE_ENV === 'development') {
+if (NODE_ENV === 'development') {
   app.get('/nocache', async (req, res) => {
     await updateCache();
     const cache = await getCache();


### PR DESCRIPTION
Closes #15 , depends on #20 . Adds a `GET /nocache` route, if `NODE_ENV` is set to `development`.

The only file that really changed is from `ralts` the `index.ts` file. The rest is merged from #20 , so i was able to use environment variables. So actually only [e441b83](https://github.com/RopFoo/tonemato/pull/22/commits/e441b8340dd9b1d2455ffe2abd6e7f6ec7d35308) is really relevant :D