### PR TITLE
Bugfix husky eslint linting errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-packages/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+packages/

--- a/packages/eslint-config-server/index.js
+++ b/packages/eslint-config-server/index.js
@@ -9,5 +9,6 @@ module.exports = {
 
   rules: {
     'prettier/prettier': 'warn',
+    'no-unused-var': 0
   },
 };

--- a/packages/eslint-config-server/index.js
+++ b/packages/eslint-config-server/index.js
@@ -9,6 +9,6 @@ module.exports = {
 
   rules: {
     'prettier/prettier': 'warn',
-    'no-unused-var': 0
+    'no-unused-vars': 0
   },
 };

--- a/packages/tonemato-utils/src/__tests__/dates.test.ts
+++ b/packages/tonemato-utils/src/__tests__/dates.test.ts
@@ -10,7 +10,7 @@ describe('isTimePassed', () => {
   it('should be passed one day ago', () => {
     // create yesterday
     const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setDate(yesterday.getDate() - 1.1);
 
     const isPassed = isTimePassed({
       date: yesterday,


### PR DESCRIPTION
Fixes #28

## Solutions
* Add `no-unused-var` so drilbur can lint, see: https://github.com/prettier/eslint-plugin-prettier/issues/306#issuecomment-783397862
* Add `.eslintignore`, so eslint does not try to lint unconfigured `packages`, see: https://github.com/okonet/lint-staged/issues/123#issuecomment-273438957
* Change `yesterday.getDate() - 1.1` to `yesterday.getDate() - 1` to widen the delta of the point in time being yesterday and checking if `now` is exactly one day ago.