### PR TITLE
Add Mock endpoint to drilbur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ gitignore
 # System Files
 .DS_Store
 Thumbs.db
+
+mock.json

--- a/apps/drilbur/src/helper/mockdata.ts
+++ b/apps/drilbur/src/helper/mockdata.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import fs from 'fs/promises';
+
+const MOCKFILEPATH = path.resolve(__dirname, '..', 'res', 'mock.json');
+
+export const mockDataExists = async () =>
+  (await fs.readdir(path.dirname(MOCKFILEPATH))).includes(
+    path.basename(MOCKFILEPATH)
+  );
+
+export const saveMockData = async (content: any) =>
+  await fs.writeFile(MOCKFILEPATH, JSON.stringify(content));
+
+export const loadMockData = async () =>
+  JSON.parse(await fs.readFile(MOCKFILEPATH, { encoding: 'utf-8' }));

--- a/apps/drilbur/src/index.ts
+++ b/apps/drilbur/src/index.ts
@@ -1,10 +1,11 @@
+import fs from 'fs/promises';
+import path from 'path';
 import express from 'express';
 import scrapeSites from './websites';
+import { mockDataExists, loadMockData, saveMockData } from './helper/mockdata';
 const app = express();
 
-const {
-  DRILBUR_PORT
-} = process.env
+const { DRILBUR_PORT, NODE_ENV } = process.env;
 
 app.get('/', (req, res) => {
   res.json({
@@ -17,5 +18,14 @@ app.get('/scrape', async (req, res) => {
 
   return res.json(scrapeResults);
 });
+
+if (NODE_ENV === 'development') {
+  app.get('/mock', async (req, res) => {
+    if (!(await mockDataExists()) || req.query.refresh === 'true')
+      await saveMockData(await scrapeSites('guitar', 'looking for musician'));
+
+    return res.json(await loadMockData());
+  });
+}
 
 app.listen(DRILBUR_PORT || 3001);


### PR DESCRIPTION
### Changes
* `drilbur` now incorporates a `/mock` endpoint duriung `NODE_ENV === development` which will scrape the websites on initial request to store a `mock.json` file. After that, always the saved `mock.json` will be returned.
* A `refresh` query parameter can be set to `true` to regenerate the `mock.json` file for example if the scraped data structure changed, example: `http://drilbururl/mock?refresh=true`

Closes #37 